### PR TITLE
Panel should inject IRequest not Request

### DIFF
--- a/LiveTranslator/Panel/Panel.php
+++ b/LiveTranslator/Panel/Panel.php
@@ -25,17 +25,17 @@ class Panel extends Nette\Object implements Nette\Diagnostics\IBarPanel
 	/** @var Translator */
 	protected $translator;
 
-	/** @var Nette\Http\Request */
+	/** @var Nette\Http\IRequest */
 	protected $httpRequest;
 
 
 
 	/**
 	 * @param Translator $translator
-	 * @param Nette\Http\Request $httpRequest
+	 * @param Nette\Http\IRequest $httpRequest
 	 * @throws Nette\InvalidArgumentException
 	 */
-	public function __construct(Translator $translator, Nette\Http\Request $httpRequest)
+	public function __construct(Translator $translator, Nette\Http\IRequest $httpRequest)
 	{
 		$this->translator = $translator;
 		$this->httpRequest = $httpRequest;


### PR DESCRIPTION
I have my own implementation Request which implements IRequest and it cannot be passed to Panel, because Panel needs class Nette\Http\Request, not interface Nette\Http\IRequest
