### PR TITLE
Delete string from newStrings if it is translated, add string to newStrings if it is deleted from translations

### DIFF
--- a/LiveTranslator/Panel/panel.phtml
+++ b/LiveTranslator/Panel/panel.phtml
@@ -1,4 +1,4 @@
-﻿<style type="text/css">
+<style type="text/css">
 #TranslationPanel {
 	min-width: 600px;
 }
@@ -539,7 +539,7 @@ var translationPanel = {
 			if (xmlHttp.readyState == 4) {
 				if (xmlHttp.status == 200) {
 					for (var i in translationPanel.erasedStrings) {
-						delete translationPanel.strings[translationPanel.erasedStrings[i]];
+						translationPanel.strings[translationPanel.erasedStrings[i]] = false;
 					}
 					translationPanel.updatedStrings = [];
 					translationPanel.erasedStrings = [];

--- a/LiveTranslator/Translator.php
+++ b/LiveTranslator/Translator.php
@@ -415,7 +415,7 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 		if ($translated === FALSE) {
 			$newStrings = &$this->getNewStrings();
 			$this->translatorStorage->removeTranslation($original, $lang, $this->namespace);
-			unset($newStrings[$original]);
+			$newStrings[$original] = FALSE;
 			return;
 		}
 
@@ -426,6 +426,8 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 		foreach ($translated as $variant => $string) {
 			$this->translatorStorage->setTranslation($original, $string, $lang, $variant, $this->namespace);
 		}
+		$newStrings = &$this->getNewStrings();
+		unset($newStrings[$original]);
 	}
 
 


### PR DESCRIPTION
If I delete translation it disappear from list of strings. I expect it would be marked as untranslated because after refreshing site it appears again. And if i add translation it stays in session. 

Isn't this solution better? Now, if i delete translation it is deleted from storage AND ADD to session as newString - it appears in list of strings as untranslated. And if I translate string, it is added to storage AND DELETED from session.