### PR TITLE
Bugs : Storage/NetteDatabase.php used case insensitive queries and method translate() uses unexpected vsprintf()

### DIFF
--- a/LiveTranslator/Storage/NetteDatabase.php
+++ b/LiveTranslator/Storage/NetteDatabase.php
@@ -51,7 +51,7 @@ class NetteDatabase implements \LiveTranslator\ITranslatorStorage
 			$arg[] = $namespace;
 		}
 
-		$arg[0] .= 'd.`text` = ? AND t.`lang` = ? AND t.`variant` <= ? ORDER BY t.`variant` DESC';
+		$arg[0] .= 'BINARY d.`text` = ? AND t.`lang` = ? AND t.`variant` <= ? ORDER BY t.`variant` DESC';
 		$arg[] = $original;
 		$arg[] = $lang;
 		$arg[] = $variant;
@@ -104,7 +104,7 @@ class NetteDatabase implements \LiveTranslator\ITranslatorStorage
 			$arg[] = $namespace;
 		}
 
-		$arg[0] .= "`text` = ?";
+		$arg[0] .= "BINARY `text` = ?";
 		$arg[] = $original;
 
 		$textId = $this->fetchField($arg);

--- a/LiveTranslator/Translator.php
+++ b/LiveTranslator/Translator.php
@@ -279,7 +279,7 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 	 * @return string
 	 * @throws TranslatorException
 	 */
-	public function translate($string, $count = 1)
+	public function translate($string, $count = NULL)
 	{
 		$hasVariants = FALSE;
 		if (is_array($string)) {
@@ -296,6 +296,9 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 				$args = func_get_args();
 				unset($args[0]);
 				$args = array_values($args);
+
+			} elseif ($count === NULL) {
+				$args = NULL;
 
 			} else {
 				$args = array($count);
@@ -370,7 +373,7 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 			}
 		}
 
-		if (FALSE !== strpos($translated, '%')) {
+		if ($args !== NULL AND FALSE !== strpos($translated, '%')) {
 			$tmp = str_replace(array('%label', '%name', '%value'), array('#label', '#name', '#value'), $translated);
 			if (FALSE !== strpos($tmp, '%')) {
 				$translated = vsprintf($tmp, $args);

--- a/tests/Translator.phpt
+++ b/tests/Translator.phpt
@@ -31,6 +31,9 @@ Assert::equal('jména Johnny, George',  $trans->translate(array('name %s'), 'Joh
 Assert::equal('Woohoo křičí 1 muž.',  $trans->translate(array('%2$d man screams %1$s.'), 'Woohoo', 1));
 Assert::equal('2 muži křičí "Woohoo!".', $trans->translate(array('%2$d man screams %1$s.'), 'Woohoo', 2));
 Assert::equal('Woohoo křičí 5 mužů.', $trans->translate(array('%2$d man screams %1$s.'), 'Woohoo', 5));
+Assert::equal('Tax is 21%', $trans->translate('Tax is 21%'));
+Assert::equal('Tax is 21% or 15%', $trans->translate('Tax is 21% or 15%'));
+Assert::equal('50%done', $trans->translate('50%done'));
 
 $trans->setCurrentLang('en');
 


### PR DESCRIPTION
# NetteDatabase.php

Translation of string `SOMETHING` affects even string `something` - it's not right behavior.
# Translator.php

There is a bug in `translate()` method. Function `vsprintf()` creates these formats:
(from en to en - no translate, just formating originals)

``` php
$translator->translate("Tax is 21%"); // "Tax is 21"
$translator->translate("Tax is 21% or 15%"); // triggers error "Warning vsprintf(): Too few arguments"
$translator->translate("50%done"); // "501one" (default parameter $count in translate() is 1)
```

**Modifications I suggest do this:**

``` php
$translator->translate("Tax is 21%"); // "Tax is 21%"
$translator->translate("Tax is 21% or 15%"); // "Tax is 21% or 15%"
$translator->translate("50%done"); // "50%done" 
```

default parameter `$count` in `translate()` is NULL - so no using `vsprintf()`

these are the same:

``` php
$translator->translate("I have %d pieces of %s", 15, 'something'); // "I have 15 pieces of something"
$translator->translate(array("Car", "Cars")); // "Car" because of line 328 $count = 1;
```
