### PR TITLE
Caching database storage and untranslated strings

### DIFF
--- a/LiveTranslator/Storage/NetteDatabase.php
+++ b/LiveTranslator/Storage/NetteDatabase.php
@@ -51,7 +51,7 @@ class NetteDatabase implements \LiveTranslator\ITranslatorStorage
 			$arg[] = $namespace;
 		}
 
-		$arg[0] .= 'd.`text` = ? AND t.`lang` = ? AND t.`variant` <= ? ORDER BY t.`variant` DESC';
+		$arg[0] .= 'BINARY d.`text` = ? AND t.`lang` = ? AND t.`variant` <= ? ORDER BY t.`variant` DESC';
 		$arg[] = $original;
 		$arg[] = $lang;
 		$arg[] = $variant;
@@ -104,7 +104,7 @@ class NetteDatabase implements \LiveTranslator\ITranslatorStorage
 			$arg[] = $namespace;
 		}
 
-		$arg[0] .= "`text` = ?";
+		$arg[0] .= "BINARY `text` = ?";
 		$arg[] = $original;
 
 		$textId = $this->fetchField($arg);

--- a/LiveTranslator/Translator.php
+++ b/LiveTranslator/Translator.php
@@ -487,7 +487,7 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 	{
 		if (isset($this->cache)) {
 			$ns = $this->namespace ?: 'default';
-			$strings = $this->cache->load("newStrings-$ns");
+			$strings = (array) $this->cache->load("newStrings-$ns");
 
 		} else {
 			// todo mohlo by to mít jednu section a ns by byly jednotlivý property zde

--- a/LiveTranslator/Translator.php
+++ b/LiveTranslator/Translator.php
@@ -279,7 +279,7 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 	 * @return string
 	 * @throws TranslatorException
 	 */
-	public function translate($string, $count = 1)
+	public function translate($string, $count = NULL)
 	{
 		$hasVariants = FALSE;
 		if (is_array($string)) {
@@ -296,6 +296,9 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 				$args = func_get_args();
 				unset($args[0]);
 				$args = array_values($args);
+
+			} elseif ($count === NULL) {
+				$args = NULL;
 
 			} else {
 				$args = array($count);
@@ -370,7 +373,7 @@ class Translator extends Nette\Object implements Nette\Localization\ITranslator
 			}
 		}
 
-		if (FALSE !== strpos($translated, '%')) {
+		if ($args !== NULL AND FALSE !== strpos($translated, '%')) {
 			$tmp = str_replace(array('%label', '%name', '%value'), array('#label', '#name', '#value'), $translated);
 			if (FALSE !== strpos($tmp, '%')) {
 				$translated = vsprintf($tmp, $args);

--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ services:
 	translatorStorage: LiveTranslator\Storage\NetteDatabase(localization_text, localization)
 ```
 
-*You can rename tables in SQL script (use the same names in config file).*
+*You can rename tables in SQL script (use the same names in config file).*   
+In default `LiveTranslator\Storage\NetteDatabase` uses `Nette\Caching`. For disabling this function use `cacheDisable()` method:  
+```
+services:
+	translatorStorage: 
+		class: LiveTranslator\Storage\NetteDatabase(localization_text, localization)
+		setup:
+			- cacheDisable()
+```
 
 - **I am using [Dibi](http://dibiphp.com/)**
 
@@ -93,6 +101,16 @@ nette:
 services:
 	translator: LiveTranslator\Translator(en)
 	translatorPanel: LiveTranslator\Panel
+```
+
+In default `LiveTranslator\Translator` uses `Nette\Caching` for storage untranslated strings. For disabling caching use `cacheDisable()` method. Then will be use SEESIONS:  
+```
+services:
+	translator: 
+		class: LiveTranslator\Translator(en)
+		setup:
+			- cacheDisable()
+	...
 ```
 
 

--- a/tests/Panel.phpt
+++ b/tests/Panel.phpt
@@ -5,7 +5,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 
 require __DIR__.'/storage/simple.php';
 
-$trans = new \LiveTranslator\Translator('en', new SimpleStorage, $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('en', new SimpleStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 $panel = new \LiveTranslator\Panel($trans, $container->getService('httpRequest'));
 
 Assert::type('LiveTranslator\Translator', $panel->getTranslator());

--- a/tests/Translator.exceptions.phpt
+++ b/tests/Translator.exceptions.phpt
@@ -6,10 +6,10 @@ $container = require __DIR__ . '/bootstrap.application.php';
 require __DIR__.'/storage/dummy.php';
 
 Assert::exception(function() use($container){
-	new \LiveTranslator\Translator('', new DummyStorage, $container->getService('session'), $container->getService('application'));
+	new \LiveTranslator\Translator('', new DummyStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 }, 'LiveTranslator\TranslatorException');
 
-$trans = new \LiveTranslator\Translator('en', new DummyStorage, $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('en', new DummyStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setAvailableLanguages(array(
 	'en', 'cz'
@@ -23,7 +23,7 @@ Assert::exception(function() use($trans){
 	$trans->setDefaultLang('de');
 }, 'LiveTranslator\TranslatorException');
 
-$trans = new \LiveTranslator\Translator('de', new DummyStorage(), $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('de', new DummyStorage(), $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 Assert::exception(function() use($trans){
 	$trans->setAvailableLanguages(array(
@@ -31,7 +31,7 @@ Assert::exception(function() use($trans){
 	));
 }, 'LiveTranslator\TranslatorException');
 
-$trans = new \LiveTranslator\Translator('en', new DummyStorage(), $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('en', new DummyStorage(), $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setCurrentLang('de');
 

--- a/tests/Translator.getAll.phpt
+++ b/tests/Translator.getAll.phpt
@@ -6,7 +6,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 require __DIR__.'/storage/simple.php';
 
 use \LiveTranslator\Translator as Tr;
-$trans = new Tr('en', new SimpleStorage, $container->getService('session'), $container->getService('application'));
+$trans = new Tr('en', new SimpleStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setCurrentLang('cz');
 

--- a/tests/Translator.langSwitch.phpt
+++ b/tests/Translator.langSwitch.phpt
@@ -6,7 +6,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 require __DIR__.'/storage/language.php';
 
 use \LiveTranslator\Translator as Tr;
-$trans = new Tr('en', new LanguageStorage, $container->getService('session'), $container->getService('application'));
+$trans = new Tr('en', new LanguageStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setCurrentLang('cz');
 

--- a/tests/Translator.minimum.phpt
+++ b/tests/Translator.minimum.phpt
@@ -5,6 +5,6 @@ $container = require __DIR__ . '/bootstrap.application.php';
 
 require __DIR__.'/storage/dummy.php';
 
-$trans = new \LiveTranslator\Translator('en', new DummyStorage, $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('en', new DummyStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 Assert::equal('hello', $trans->translate('hello'));

--- a/tests/Translator.namespaces.phpt
+++ b/tests/Translator.namespaces.phpt
@@ -6,7 +6,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 require __DIR__.'/storage/namespace.php';
 
 use \LiveTranslator\Translator as Tr;
-$trans = new Tr('en', new NamespaceStorage, $container->getService('session'), $container->getService('application'));
+$trans = new Tr('en', new NamespaceStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setCurrentLang('cz')
 	->setNamespace('first');

--- a/tests/Translator.phpt
+++ b/tests/Translator.phpt
@@ -5,7 +5,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 
 require __DIR__.'/storage/simple.php';
 
-$trans = new \LiveTranslator\Translator('en', new SimpleStorage, $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('en', new SimpleStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setCurrentLang('cz')
 	->setAvailableLanguages(array(

--- a/tests/Translator.phpt
+++ b/tests/Translator.phpt
@@ -31,6 +31,9 @@ Assert::equal('jména Johnny, George',  $trans->translate(array('name %s'), 'Joh
 Assert::equal('Woohoo křičí 1 muž.',  $trans->translate(array('%2$d man screams %1$s.'), 'Woohoo', 1));
 Assert::equal('2 muži křičí "Woohoo!".', $trans->translate(array('%2$d man screams %1$s.'), 'Woohoo', 2));
 Assert::equal('Woohoo křičí 5 mužů.', $trans->translate(array('%2$d man screams %1$s.'), 'Woohoo', 5));
+Assert::equal('Tax is 21%', $trans->translate('Tax is 21%'));
+Assert::equal('Tax is 21% or 15%', $trans->translate('Tax is 21% or 15%'));
+Assert::equal('50%done', $trans->translate('50%done'));
 
 $trans->setCurrentLang('en');
 

--- a/tests/Translator.remove.phpt
+++ b/tests/Translator.remove.phpt
@@ -6,7 +6,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 require __DIR__.'/storage/simple.php';
 
 use \LiveTranslator\Translator as Tr;
-$trans = new Tr('en', new SimpleStorage, $container->getService('session'), $container->getService('application'));
+$trans = new Tr('en', new SimpleStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setCurrentLang('cz');
 

--- a/tests/Translator.set.phpt
+++ b/tests/Translator.set.phpt
@@ -5,7 +5,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 
 require __DIR__.'/storage/simple.php';
 
-$trans = new \LiveTranslator\Translator('en', new SimpleStorage, $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('en', new SimpleStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 
 $trans->setCurrentLang('cz')
 	->setAvailableLanguages(array(

--- a/tests/Translator.variants.phpt
+++ b/tests/Translator.variants.phpt
@@ -5,7 +5,7 @@ $container = require __DIR__ . '/bootstrap.application.php';
 
 require __DIR__.'/storage/dummy.php';
 
-$trans = new \LiveTranslator\Translator('cz', new DummyStorage, $container->getService('session'), $container->getService('application'));
+$trans = new \LiveTranslator\Translator('cz', new DummyStorage, $container->getService('session'), $container->getService('application'), $container->getService('cache.storage'));
 $trans::$defaultPluralForms = 'nplurals=2; plural=(n==1) ? 0 : 1;';
 
 Assert::equal(2, $trans->getVariantsCount());

--- a/tests/bootstrap.application.php
+++ b/tests/bootstrap.application.php
@@ -11,6 +11,21 @@ if (!class_exists('Tester\Assert')){
 
 Tester\Environment::setup();
 
+// For caching lock tests and clean up cache dir
+@mkdir($dir = __DIR__ . '/temp/lock');
+Tester\Environment::lock('cache', $dir);
+
+if (is_dir($dir = __DIR__ . '/temp/cache/_VladaHejda.LiveTranslator')) {
+	$h = opendir($dir);
+	while ($file = readdir($h)) {
+		if (is_dir($file)) {
+			continue;
+		}
+		unlink("$dir/$file");
+	}
+}
+
+
 $configurator = new Nette\Configurator;
 $configurator->setTempDirectory(__DIR__ . '/temp');
 return $configurator->createContainer();


### PR DESCRIPTION
- I had many SQL queries with NetteDatabase storage, caching solves it
- Caching untranslated strings : this is described in nette forum (comment by Robyer at point "2." ) https://forum.nette.org/en/19181-livetranslator-forked-nettetranslator#p5822 

I just don't know if it is correct to have it as the default behavior.
